### PR TITLE
[PR] Expand Museum Exhibits

### DIFF
--- a/articles/post-museum-exhibit.php
+++ b/articles/post-museum-exhibit.php
@@ -1,0 +1,144 @@
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+
+	<header class="article-header">
+		<hgroup>
+			<?php if ( is_single() ) : ?>
+				<?php if ( spine_get_option( 'articletitle_show' ) == 'true' ) : ?>
+					<h1 class="article-title"><?php the_title(); ?></h1>
+					<h2 class="article-artist"><?php echo esc_html( wsu_museum_get_exhibit_artist() ); ?></h2>
+				<?php endif; ?>
+			<?php else : ?>
+				<h2 class="article-title">
+					<a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
+				</h2>
+				<h3 class="article-artist"><?php echo esc_html( wsu_museum_get_exhibit_artist() ); ?></h3>
+			<?php endif;  ?>
+		</hgroup>
+	</header>
+
+	<?php if ( ! is_singular() ) : ?>
+		<div class="article-summary">
+			<?php
+
+			if ( spine_has_thumbnail_image() ) {
+				?><figure class="article-thumbnail"><a href="<?php the_permalink(); ?>"><?php spine_the_thumbnail_image(); ?></a></figure><?php
+			} elseif ( spine_has_featured_image() ) {
+				?><figure class="article-thumbnail"><a href="<?php the_permalink(); ?>"><?php the_post_thumbnail( 'spine-thumbnail_size' ); ?></a></figure><?php
+			}
+
+			// If a manual excerpt is available, default to that. If `<!--more-->` exists in content, default
+			// to that. If an option is set specifically to display excerpts, default to that. Otherwise show
+			// full content.
+			if ( $post->post_excerpt ) {
+				echo get_the_excerpt() . ' <a href="' . get_permalink() . '"><span class="excerpt-more-default">&raquo; More ...</span></a>';
+			} elseif ( strstr( $post->post_content, '<!--more-->' ) ) {
+				the_content( '<span class="content-more-default">&raquo; More ...</span>' );
+			} elseif ( 'excerpt' === spine_get_option( 'archive_content_display' ) ) {
+				the_excerpt();
+			} else {
+				the_content();
+			}
+
+			?>
+		</div><!-- .article-summary -->
+	<?php else : ?>
+		<div class="article-body">
+			<?php the_content(); ?>
+			<?php wp_link_pages( array( 'before' => '<div class="page-links">' . __( 'Pages:', 'spine' ), 'after' => '</div>' ) ); ?>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( comments_open() && is_singular() ) : ?>
+		<blockquote class="comments">
+
+		</blockquote>
+	<?php endif; // comments_open() ?>
+
+	<footer class="article-footer">
+		<?php
+		// Display site level categories attached to the post.
+		if ( has_category() ) {
+			echo '<dl class="categorized">';
+			echo '<dt><span class="categorized-default">Categorized</span></dt>';
+			foreach( get_the_category() as $category ) {
+				echo '<dd><a href="' . get_category_link( $category->cat_ID ) . '">' . $category->cat_name . '</a></dd>';
+			}
+			echo '</dl>';
+		}
+
+		// Display University categories attached to the post.
+		if ( has_term( '', 'wsuwp_university_category' ) ) {
+			$university_category_terms = get_the_terms( get_the_ID(), 'wsuwp_university_category' );
+			if ( ! is_wp_error( $university_category_terms ) ) {
+				echo '<dl class="university-categorized">';
+				echo '<dt><span class="university-categorized-default">Categorized</span></dt>';
+
+				foreach ( $university_category_terms as $term ) {
+					$term_link = get_term_link( $term->term_id, 'wsuwp_university_category' );
+					if ( ! is_wp_error( $term_link ) ) {
+						echo '<dd><a href="' . esc_url( $term_link ) . '">' . $term->name . '</a></dd>';
+					}
+				}
+				echo '</dl>';
+			}
+		}
+
+		// Display University tags attached to the post.
+		if ( has_tag() ) {
+			echo '<dl class="tagged">';
+			echo '<dt><span class="tagged-default">Tagged</span></dt>';
+			foreach( get_the_tags() as $tag ) {
+				echo '<dd><a href="' . get_tag_link( $tag->term_id ) . '">' . $tag->name . '</a></dd>';
+			}
+			echo '</dl>';
+		}
+
+		// Display University locations attached to the post.
+		if ( has_term( '', 'wsuwp_university_location' ) ) {
+			$university_location_terms = get_the_terms( get_the_ID(), 'wsuwp_university_location' );
+			if ( ! is_wp_error( $university_location_terms ) ) {
+				echo '<dl class="university-location">';
+				echo '<dt><span class="university-location-default">Location</span></dt>';
+
+				foreach ( $university_location_terms as $term ) {
+					$term_link = get_term_link( $term->term_id, 'wsuwp_university_location' );
+					if ( ! is_wp_error( $term_link ) ) {
+						echo '<dd><a href="' . esc_url( $term_link ) . '">' . $term->name . '</a></dd>';
+					}
+				}
+				echo '</dl>';
+			}
+		}
+
+		// Comments Allowed
+		// if ( comments_open()) {}
+
+		// If the user viewing the post can edit it, show an edit link.
+		if ( current_user_can( 'edit_post', $post->ID ) && ! is_singular() ) {
+			?><dl class="editors"><?php edit_post_link( 'Edit', '<span class="edit-link">', '</span>' ); ?></dl><?php
+		}
+
+		// If a user has filled out their description and this is a multi-author blog, show a bio on their entries.
+		if ( is_singular() && get_the_author_meta( 'description' ) && is_multi_author() ) : ?>
+			<div class="author-info">
+				<div class="author-avatar">
+					<?php
+					/** This filter is documented in author.php */
+					$author_bio_avatar_size = apply_filters( 'twentytwelve_author_bio_avatar_size', 68 );
+					echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );
+					?>
+				</div><!-- .author-avatar -->
+				<div class="author-description">
+					<h2><?php printf( __( 'About %s', 'twentytwelve' ), get_the_author() ); ?></h2>
+					<p><?php the_author_meta( 'description' ); ?></p>
+					<div class="author-link">
+						<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+							<?php printf( __( 'View all posts by %s <span class="meta-nav">&rarr;</span>', 'twentytwelve' ), get_the_author() ); ?>
+						</a>
+					</div><!-- .author-link	-->
+				</div><!-- .author-description -->
+			</div><!-- .author-info -->
+		<?php endif; ?>
+	</footer><!-- .entry-meta -->
+
+</article>

--- a/functions.php
+++ b/functions.php
@@ -66,7 +66,14 @@ class WSU_Museum_Theme {
 		if ( 'museum-exhibit' !== $post_type ) {
 			return;
 		}
+		add_meta_box( 'museum_sidebar_content', 'Sidebar Content', array( $this, 'display_sidebar_content_meta_box' ), 'museum-exhibit', 'normal' );
 		add_meta_box( 'museum_exhibit_artist', 'Artist Text', array( $this, 'display_artist_text_meta_box' ), 'museum-exhibit', 'normal' );
+	}
+
+	public function display_sidebar_content_meta_box( $post ) {
+		$content = $this->get_sidebar_content( $post->ID );
+
+		wp_editor( $content, 'exhibit_sidebar_content' );
 	}
 
 	public function display_artist_text_meta_box( $post ) {
@@ -98,11 +105,14 @@ class WSU_Museum_Theme {
 			return;
 		}
 
-		if ( ! isset( $_POST['artist_text'] ) ) {
-			return;
+		if ( isset( $_POST['artist_text'] ) ) {
+			update_post_meta( $post_id, '_exhibit_artist_text', sanitize_text_field( $_POST['artist_text'] ) );
 		}
 
-		update_post_meta( $post_id, '_exhibit_artist_text', sanitize_text_field( $_POST['artist_text'] ) );
+		if ( isset( $_POST['exhibit_sidebar_content'] ) ) {
+			$content = wp_kses_post( $_POST['exhibit_sidebar_content'] );
+			update_post_meta( $post_id, '_exhibit_sidebar_content', $content );
+		}
 
 		return;
 	}
@@ -144,6 +154,12 @@ class WSU_Museum_Theme {
 		return '';
 	}
 
+	public function get_sidebar_content( $post_id ) {
+		$content = get_post_meta( $post_id, '_exhibit_sidebar_content', true );
+
+		return $content;
+	}
+
 	public function get_exhibit_artist( $post_id ) {
 		$artist = get_post_meta( $post_id, '_exhibit_artist_text', true );
 
@@ -151,6 +167,17 @@ class WSU_Museum_Theme {
 	}
 }
 $wsu_museum_theme = new WSU_Museum_Theme();
+
+/**
+ * Retrieve the content used for the sidebar on an exhibit.
+ *
+ * @return string
+ */
+function wsu_museum_get_sidebar_content() {
+	global $wsu_museum_theme;
+
+	return $wsu_museum_theme->get_sidebar_content( get_the_ID() );
+}
 
 /**
  * Retrieve the text used to display an exhibit's artist.

--- a/functions.php
+++ b/functions.php
@@ -66,14 +66,21 @@ class WSU_Museum_Theme {
 		if ( 'museum-exhibit' !== $post_type ) {
 			return;
 		}
+		add_meta_box( 'museum_exhibit_artist', 'Artist Text', array( $this, 'display_artist_text_meta_box' ), 'museum-exhibit', 'normal', 'high' );
+		add_meta_box( 'museum_gallery_content', 'Gallery Content', array( $this, 'display_gallery_content_meta_box' ), 'museum-exhibit', 'normal' );
 		add_meta_box( 'museum_sidebar_content', 'Sidebar Content', array( $this, 'display_sidebar_content_meta_box' ), 'museum-exhibit', 'normal' );
-		add_meta_box( 'museum_exhibit_artist', 'Artist Text', array( $this, 'display_artist_text_meta_box' ), 'museum-exhibit', 'normal' );
 	}
 
 	public function display_sidebar_content_meta_box( $post ) {
 		$content = $this->get_sidebar_content( $post->ID );
 
 		wp_editor( $content, 'exhibit_sidebar_content' );
+	}
+
+	public function display_gallery_content_meta_box( $post ) {
+		$content = $this->get_gallery_content( $post->ID );
+
+		wp_editor( $content, 'exhibit_gallery_content' );
 	}
 
 	public function display_artist_text_meta_box( $post ) {
@@ -112,6 +119,11 @@ class WSU_Museum_Theme {
 		if ( isset( $_POST['exhibit_sidebar_content'] ) ) {
 			$content = wp_kses_post( $_POST['exhibit_sidebar_content'] );
 			update_post_meta( $post_id, '_exhibit_sidebar_content', $content );
+		}
+
+		if ( isset( $_POST['exhibit_gallery_content'] ) ) {
+			$content = wp_kses_post( $_POST['exhibit_gallery_content'] );
+			update_post_meta( $post_id, '_exhibit_gallery_content', $content );
 		}
 
 		return;
@@ -160,6 +172,12 @@ class WSU_Museum_Theme {
 		return $content;
 	}
 
+	public function get_gallery_content( $post_id ) {
+		$content = get_post_meta( $post_id, '_exhibit_gallery_content', true );
+
+		return $content;
+	}
+
 	public function get_exhibit_artist( $post_id ) {
 		$artist = get_post_meta( $post_id, '_exhibit_artist_text', true );
 
@@ -177,6 +195,17 @@ function wsu_museum_get_sidebar_content() {
 	global $wsu_museum_theme;
 
 	return $wsu_museum_theme->get_sidebar_content( get_the_ID() );
+}
+
+/**
+ * Retrieve the gallery content for an exhibit.
+ *
+ * @return string
+ */
+function wsu_museum_get_gallery_content() {
+	global $wsu_museum_theme;
+
+	return $wsu_museum_theme->get_gallery_content( get_the_ID() );
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -13,8 +13,14 @@ class WSU_Museum_Theme {
 		}
 	}
 
+	/**
+	 * Enqueue scripts used by the Museum theme.
+	 */
 	public function enqueue_scripts() {
-		wp_enqueue_script( 'wsu-cycle', get_template_directory_uri() . '/js/cycle2/jquery.cycle2.min.js', array( 'jquery' ), spine_get_script_version(), true );
+		// Ensure the slideshow script is enqueued on individual exhibit pages.
+		if ( is_singular( 'museum-exhibit' ) ) {
+			wp_enqueue_script( 'wsu-cycle', get_template_directory_uri() . '/js/cycle2/jquery.cycle2.min.js', array( 'jquery' ), spine_get_script_version(), true );
+		}
 	}
 
 	/**

--- a/parts/single-layout-museum-exhibit.php
+++ b/parts/single-layout-museum-exhibit.php
@@ -15,3 +15,9 @@
 	</div>
 
 </section>
+
+<section class="row single gutter pad-ends museum-gallery">
+	<div class="column one">
+		<?php echo apply_filters( 'the_content', wsu_museum_get_gallery_content() ); ?>
+	</div>
+</section>

--- a/parts/single-layout-museum-exhibit.php
+++ b/parts/single-layout-museum-exhibit.php
@@ -1,4 +1,4 @@
-<section class="row single gutter pad-ends">
+<section class="row side-right gutter pad-ends">
 
 	<div class="column one">
 
@@ -9,5 +9,9 @@
 		<?php endwhile; ?>
 
 	</div><!--/column-->
+
+	<div class="column two">
+		<?php echo apply_filters( 'the_content', wsu_museum_get_sidebar_content() ); ?>
+	</div>
 
 </section>

--- a/style.css
+++ b/style.css
@@ -8,22 +8,22 @@
  Version:        0.0.1
 */
 
-.cycle-slideshow {
+.single-museum-exhibit .cycle-slideshow {
 	width: 100%;
 	height: 600px;
 }
 
-.exhibit-banner-slide {
+.single-museum-exhibit .exhibit-banner-slide {
 	width: 100%;
 	height: 100%;
 	display: none;
 }
 
-.exhibit-banner-slide:first-of-type {
+.single-museum-exhibit .exhibit-banner-slide:first-of-type {
 	display: block;
 }
 
-.cycle-pager {
+.single-museum-exhibit .cycle-pager {
 	position: absolute;
 	bottom: 0;
 	z-index: 12000;


### PR DESCRIPTION
- [x] Only enqueue styles and scripts for sliders on specific exhibit pages to avoid conflict with page sliders.
- [x] Capture and display artist text to use as a subhead for exhibit displays.
- [x] Provide a method for capturing and displaying sidebar content in single exhibit views.
- [x] Provide a method for displaying gallery content below main and sidebar content.
- [x] Lightbox effect when clicking on individual gallery items.
